### PR TITLE
fix(api): resolve Arcade type conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeai/arcadejs",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The official TypeScript library for the Arcade API",
   "author": "Arcade <dev@arcade.dev>",
   "types": "dist/index.d.ts",

--- a/src/lib/zod/zod.ts
+++ b/src/lib/zod/zod.ts
@@ -1,7 +1,7 @@
 import { ExecuteToolResponse, ToolDefinition } from '../../resources/tools/tools';
 import { ToolAuthorizationResponse, ZodTool, ZodToolSchema } from './types';
 import { z } from 'zod';
-import { type Arcade } from '../../index';
+import { type Arcade } from '@arcadeai/arcadejs';
 
 /**
  * Checks if an error indicates that authorization for the tool is required

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.3.0'; // x-release-please-version
+export const VERSION = '1.4.1'; // x-release-please-version


### PR DESCRIPTION
Switched import to use our @arcadeai/arcadejs tsconfig alias. This keeps TypeScript using one consistent type definition and fixes this error:

`Two different types with this name exist, but they are unrelated.`