### PR TITLE
fix(api): fix ArcadeClient type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeai/arcadejs",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "The official TypeScript library for the Arcade API",
   "author": "Arcade <dev@arcade.dev>",
   "types": "dist/index.d.ts",
@@ -98,6 +98,11 @@
       "types": "./dist/_shims/auto/*.d.ts",
       "require": "./dist/_shims/auto/*.js",
       "default": "./dist/_shims/auto/*.mjs"
+    },
+    "./lib": {
+      "types": "./dist/lib/index.d.ts",
+      "require": "./dist/lib/index.js",
+      "default": "./dist/lib/index.mjs"
     },
     ".": {
       "require": {

--- a/src/lib/zod/zod.ts
+++ b/src/lib/zod/zod.ts
@@ -1,7 +1,9 @@
 import { ExecuteToolResponse, ToolDefinition } from '../../resources/tools/tools';
 import { ToolAuthorizationResponse, ZodTool, ZodToolSchema } from './types';
 import { z } from 'zod';
-import { type Arcade } from '@arcadeai/arcadejs';
+import type { Arcade } from '../../index';
+
+type ArcadeClient = Omit<Arcade, '_options'>;
 
 /**
  * Checks if an error indicates that authorization for the tool is required
@@ -129,7 +131,7 @@ export function createZodTool({
   userId,
 }: {
   tool: ToolDefinition;
-  client: Arcade;
+  client: ArcadeClient;
   userId: string;
 }): ZodTool {
   const schema = convertSingleToolToSchema(tool);
@@ -201,7 +203,7 @@ export function toZod({
   userId,
 }: {
   tools: ToolDefinition[];
-  client: Arcade;
+  client: ArcadeClient;
   userId: string;
 }): ZodTool[] {
   return tools.map((tool) => createZodTool({ tool, client, userId }));

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.4.1'; // x-release-please-version
+export const VERSION = '1.4.2'; // x-release-please-version


### PR DESCRIPTION
### **Type Error Fix:**
TypeScript gets confused when you import the same type from different paths, even if it’s from the same package. This is giving us the following error:

```
Two different types with this name exist, but they are unrelated.
    Types have separate declarations of a private property '_options'.ts(2719)
````
The fix is to Omit the `_options` private property.


### **Import Path Improvement:**
I updated the `package.json` so that **index.ts** is the default export in the lib folder. This means we can clean up our imports:
```typescript
// Before
import { toZod } from "@arcadeai/arcadejs/lib/index.mjs";

// After
import { toZod } from "@arcadeai/arcadejs/lib";
````
@nbarbettini, what do you think? Would you rather have the export come from `@arcadeai/arcadejs/lib` or just straight from `@arcadeai/arcadejs`?