### PR TITLE
Add toZodToolSet utility fn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeai/arcadejs",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "The official TypeScript library for the Arcade API",
   "author": "Arcade <dev@arcade.dev>",
   "types": "dist/index.d.ts",

--- a/src/lib/zod/types.ts
+++ b/src/lib/zod/types.ts
@@ -14,7 +14,8 @@ export interface ToolAuthorizationResponse {
 }
 
 /**
- * Base interface for all tool schemas with Zod validation
+ * Schema definition for an Arcade tool, containing the tool's name,
+ * description, and Zod-validated parameter structure.
  */
 export interface ZodToolSchema {
   /** Qualified name of the tool */
@@ -26,11 +27,6 @@ export interface ZodToolSchema {
   /** Zod schema for validating tool output (if any) */
   output: z.ZodType | undefined;
 }
-
-/**
- * Union type for all possible tool execution responses
- */
-export type ToolResponse<T extends unknown = unknown> = ExecuteToolResponse | ToolAuthorizationResponse | T;
 
 /**
  * Generic type for any tool execution function
@@ -59,7 +55,7 @@ export interface ToolExecuteFunctionFactoryInput {
   zodToolSchema: ZodToolSchema;
   /** Arcade client instance */
   client: ArcadeClient;
-  /** User ID for tool execution */
+  /** User ID for tool execution/authorization */
   userId: string;
 }
 

--- a/src/lib/zod/types.ts
+++ b/src/lib/zod/types.ts
@@ -1,5 +1,6 @@
+import type { Arcade } from '../../index';
 import { AuthorizationResponse } from '../../resources/shared';
-import { ExecuteToolResponse } from '../../resources/tools/tools';
+import { ExecuteToolResponse, ToolDefinition } from '../../resources/tools/tools';
 import { z } from 'zod';
 
 /**
@@ -13,26 +14,75 @@ export interface ToolAuthorizationResponse {
 }
 
 /**
- * Represents a tool with Zod schema validation and execution capabilities.
+ * Base interface for all tool schemas with Zod validation
  */
-export interface ZodTool {
+export interface ZodToolSchema {
+  /** Qualified name of the tool */
   name: string;
-  description: string | undefined;
+  /** Optional, human-readable description */
+  description?: string | undefined;
+  /** Zod schema for validating tool parameters */
   parameters: z.ZodType;
+  /** Zod schema for validating tool output (if any) */
   output: z.ZodType | undefined;
-  execute: <T extends unknown>(input: T) => Promise<ExecuteToolResponse>;
-  executeOrAuthorize: <T extends unknown>(
-    input: T,
-  ) => Promise<ExecuteToolResponse | ToolAuthorizationResponse>;
 }
 
 /**
- * Schema definition for an Arcade tool, containing the tool's name,
- * description, and Zod-validated parameter structure.
+ * Union type for all possible tool execution responses
  */
-export interface ZodToolSchema {
-  name: string;
-  description: string | undefined;
-  parameters: z.ZodType;
-  output: z.ZodType | undefined;
+export type ToolResponse<T extends unknown = unknown> = ExecuteToolResponse | ToolAuthorizationResponse | T;
+
+/**
+ * Generic type for any tool execution function
+ */
+export type ToolExecuteFunction<TReturn> = (input: unknown) => Promise<TReturn>;
+
+/**
+ * A complete tool implementation with Zod validation and execution capabilities
+ */
+export interface ZodTool<TReturn = ExecuteToolResponse> extends ZodToolSchema {
+  execute: ToolExecuteFunction<TReturn>;
+}
+
+/**
+ * Arcade client
+ */
+export type ArcadeClient = Omit<Arcade, '_options'>;
+
+/**
+ * Input required to create a tool execution function
+ */
+export interface ToolExecuteFunctionFactoryInput {
+  /** Original tool definition from Arcade */
+  toolDefinition: ToolDefinition;
+  /** Zod-validated tool schema */
+  zodToolSchema: ZodToolSchema;
+  /** Arcade client instance */
+  client: ArcadeClient;
+  /** User ID for tool execution */
+  userId: string;
+}
+
+/**
+ * Base input type for tool creation functions
+ */
+export interface BaseToolCreationInput<TReturn = ExecuteToolResponse> {
+  client: ArcadeClient;
+  userId: string;
+  executeFactory?: (props: ToolExecuteFunctionFactoryInput) => ToolExecuteFunction<TReturn>;
+}
+
+/**
+ * Input required to create a single Zod tool
+ */
+export interface CreateZodToolInput<TReturn = ExecuteToolResponse> extends BaseToolCreationInput<TReturn> {
+  tool: ToolDefinition;
+}
+
+/**
+ * Input required to create multiple Zod tools
+ */
+export interface CreateMultipleZodToolsInput<TReturn = ExecuteToolResponse>
+  extends BaseToolCreationInput<TReturn> {
+  tools: ToolDefinition[];
 }

--- a/src/lib/zod/zod.ts
+++ b/src/lib/zod/zod.ts
@@ -47,7 +47,7 @@ export function convertParametersToZodSchema(parameters: ToolDefinition.Input): 
 }
 
 /**
- * Converts Arcade Tool Input Value Schema to Zod schema
+ * Converts a value schema to Zod type
  */
 function convertValueSchemaToZod(schema: {
   val_type: string;
@@ -197,7 +197,7 @@ export function createZodTool<TReturn = ExecuteToolResponse>(
 }
 
 /**
- * Converts formatted tools to full tools with execution capabilities
+ * Converts Arcade tools to zod tools with execution capabilities
  */
 export function toZod<TReturn = ExecuteToolResponse>({
   tools,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.4.2'; // x-release-please-version
+export const VERSION = '1.5.0'; // x-release-please-version

--- a/tests/lib/zod/mockData.ts
+++ b/tests/lib/zod/mockData.ts
@@ -1,0 +1,132 @@
+import { AuthorizationResponse } from '@arcadeai/arcadejs/resources/shared';
+import { ExecuteToolResponse, ToolDefinition } from '@arcadeai/arcadejs/resources/tools/tools';
+import Arcade from '@arcadeai/arcadejs/index';
+
+export const mockExecuteResponse: ExecuteToolResponse = {
+  success: true,
+  output: { value: { message: 'ok' } },
+};
+
+export const mockAuthorizationResponse: AuthorizationResponse = {
+  id: 'auth_123',
+  url: 'http://example.com/authorize',
+  status: 'pending',
+};
+
+export const mockExecute = jest.fn().mockResolvedValue(mockExecuteResponse);
+export const mockAuthorize = jest.fn().mockResolvedValue(mockAuthorizationResponse);
+export const client = new Arcade({
+  apiKey: 'My API Key',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+client.tools.execute = mockExecute;
+client.tools.authorize = mockAuthorize;
+
+export const sampleTool: ToolDefinition = {
+  fully_qualified_name: 'Github.CreateIssue@0.1.10',
+  qualified_name: 'Github.CreateIssue',
+  name: 'CreateIssue',
+  description:
+    'Create an issue in a GitHub repository.\n\nExample:\n```\ncreate_issue(\n    owner="octocat",\n    repo="Hello-World",\n    title="Found a bug",\n    body="I\'m having a problem with this.",\n    assignees=["octocat"],\n    milestone=1,\n    labels=["bug"],\n)\n```',
+  toolkit: {
+    name: 'Github',
+    description: 'LLM tools for interacting with Github',
+    version: '0.1.10',
+  },
+  input: {
+    parameters: [
+      {
+        name: 'owner',
+        required: true,
+        description: 'The account owner of the repository. The name is not case sensitive.',
+        value_schema: {
+          val_type: 'string',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'repo',
+        required: true,
+        description: 'The name of the repository without the .git extension. The name is not case sensitive.',
+        value_schema: {
+          val_type: 'string',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'title',
+        required: true,
+        description: 'The title of the issue.',
+        value_schema: {
+          val_type: 'string',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'body',
+        required: false,
+        description: 'The contents of the issue.',
+        value_schema: {
+          val_type: 'string',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'assignees',
+        required: false,
+        description: 'Logins for Users to assign to this issue.',
+        value_schema: {
+          val_type: 'array',
+          inner_val_type: 'string',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'milestone',
+        required: false,
+        description: 'The number of the milestone to associate this issue with.',
+        value_schema: {
+          val_type: 'integer',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'labels',
+        required: false,
+        description: 'Labels to associate with this issue.',
+        value_schema: {
+          val_type: 'array',
+          inner_val_type: 'string',
+        },
+        inferrable: true,
+      },
+      {
+        name: 'include_extra_data',
+        required: false,
+        description:
+          'If true, return all the data available about the pull requests. This is a large payload and may impact performance - use with caution.',
+        value_schema: {
+          val_type: 'boolean',
+        },
+        inferrable: true,
+      },
+    ],
+  },
+  output: {
+    available_modes: ['value', 'error'],
+    description:
+      "A JSON string containing the created issue's details, including id, url, title, body, state, html_url, creation and update timestamps, user, assignees, and labels. If include_extra_data is True, returns all available data about the issue.",
+    value_schema: {
+      val_type: 'string',
+    },
+  },
+  requirements: {
+    authorization: {
+      provider_id: 'github',
+      provider_type: 'oauth2',
+      oauth2: {},
+    },
+  },
+};
+
+export const userId = 'user_123';

--- a/tests/lib/zod/zod.test.ts
+++ b/tests/lib/zod/zod.test.ts
@@ -1,0 +1,240 @@
+import {
+  convertParametersToZodSchema,
+  convertSingleToolToSchema,
+  isAuthorizationRequiredError,
+  executeZodTool,
+  executeOrAuthorizeZodTool,
+  toZod,
+  toZodToolSet,
+} from '@arcadeai/arcadejs/lib/zod/zod';
+import { PermissionDeniedError } from '@arcadeai/arcadejs/error';
+import type { Headers } from '@arcadeai/arcadejs/core';
+import {
+  mockAuthorizationResponse,
+  mockExecuteResponse,
+  sampleTool,
+  userId,
+  client,
+  mockExecute,
+} from './mockData';
+
+/**
+ * Tests
+ */
+describe('isAuthorizationRequiredError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true for PermissionDeniedError name', () => {
+    const err = new PermissionDeniedError(
+      403,
+      { name: 'tool_authorization_required', message: 'authorization required' },
+      'authorization required',
+      {} as Headers,
+    );
+    expect(isAuthorizationRequiredError(err)).toBe(true);
+  });
+
+  it('returns false for other errors', () => {
+    const err = new Error('Unhandled');
+    expect(isAuthorizationRequiredError(err)).toBe(false);
+  });
+});
+
+describe('convertParametersToZodSchema', () => {
+  it('creates correct schema with required and optional params', () => {
+    const schema = convertParametersToZodSchema(sampleTool.input);
+
+    // Should parse when required field is present
+    const parsed = schema.parse({
+      owner: 'octocat',
+      repo: 'Hello-World',
+      title: 'Found a bug',
+    });
+    expect(parsed).toEqual({
+      owner: 'octocat',
+      repo: 'Hello-World',
+      title: 'Found a bug',
+    });
+
+    // Optional field may be omitted
+    expect(() =>
+      schema.parse({
+        owner: 'octocat',
+        repo: 'Hello-World',
+        title: 'Found a bug',
+        body: "I'm having a problem with this.",
+      }),
+    ).not.toThrow();
+
+    // Missing required should throw
+    expect(() =>
+      schema.parse({
+        owner: 'octocat',
+      }),
+    ).toThrow();
+  });
+
+  it('returns empty object schema when no parameters defined', () => {
+    const schema = convertParametersToZodSchema({} as any);
+    const parsed = schema.parse({});
+    expect(parsed).toEqual({});
+  });
+});
+
+describe('convertSingleToolToSchema', () => {
+  it('converts tool definition and normalizes name', () => {
+    const zodSchema = convertSingleToolToSchema(sampleTool);
+    expect(zodSchema.name).toBe('Github_CreateIssue'); // dot replaced with underscore
+    expect(zodSchema.description).toBe(sampleTool.description);
+
+    // Validate parameters
+    expect(() =>
+      zodSchema.parameters.parse({ owner: 'octocat', repo: 'Hello-World', title: 'Found a bug' }),
+    ).not.toThrow();
+  });
+});
+
+describe('executeZodTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('executes tool when input is valid', async () => {
+    const zodSchema = convertSingleToolToSchema(sampleTool);
+
+    const execFn = executeZodTool({
+      client,
+      userId,
+      zodToolSchema: zodSchema,
+      toolDefinition: sampleTool,
+    });
+
+    const result = await execFn({
+      owner: 'octocat',
+      repo: 'Hello-World',
+      title: 'Found a bug',
+    });
+
+    expect(client.tools.execute).toHaveBeenCalledWith({
+      tool_name: zodSchema.name,
+      input: {
+        owner: 'octocat',
+        repo: 'Hello-World',
+        title: 'Found a bug',
+      },
+      user_id: userId,
+    });
+    expect(result).toBe(mockExecuteResponse);
+  });
+
+  it('throws validation error on invalid input', async () => {
+    const zodSchema = convertSingleToolToSchema(sampleTool);
+
+    const execFn = executeZodTool({
+      client,
+      userId,
+      zodToolSchema: zodSchema,
+      toolDefinition: sampleTool,
+    });
+
+    // Then verify that the execution fails
+    await expect(execFn({})).rejects.toThrow('Invalid input');
+    expect(client.tools.execute).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeOrAuthorizeZodTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns authorization response when execution is not authorized', async () => {
+    const authError = new PermissionDeniedError(
+      403,
+      { name: 'tool_authorization_required', message: 'authorization required' },
+      'authorization required',
+      {} as Headers,
+    );
+    mockExecute.mockRejectedValueOnce(authError);
+
+    const zodSchema = convertSingleToolToSchema(sampleTool);
+
+    const execFn = executeOrAuthorizeZodTool({
+      client,
+      userId,
+      zodToolSchema: zodSchema,
+      toolDefinition: sampleTool,
+    });
+
+    const result = await execFn({
+      owner: 'octocat',
+      repo: 'Hello-World',
+      title: 'Found a bug',
+    });
+
+    expect(client.tools.authorize).toHaveBeenCalledWith({
+      tool_name: zodSchema.name,
+      user_id: userId,
+    });
+
+    expect(result).toEqual({
+      authorization_required: true,
+      authorization_response: mockAuthorizationResponse,
+      url: mockAuthorizationResponse.url ?? '',
+      message: expect.stringContaining('authorize'),
+    });
+  });
+
+  it('executes tool directly when authorized', async () => {
+    const zodSchema = convertSingleToolToSchema(sampleTool);
+
+    const execFn = executeOrAuthorizeZodTool({
+      client,
+      userId,
+      zodToolSchema: zodSchema,
+      toolDefinition: sampleTool,
+    });
+
+    const result = await execFn({
+      owner: 'octocat',
+      repo: 'Hello-World',
+      title: 'Found a bug',
+    });
+
+    expect(client.tools.execute).toHaveBeenCalledTimes(1);
+    expect(client.tools.authorize).not.toHaveBeenCalled();
+    expect(result).toBe(mockExecuteResponse);
+  });
+});
+
+describe('toZod and toZodToolSet', () => {
+  it('createZodTool returns executable tool', async () => {
+    const tool = toZod({ tools: [sampleTool], client, userId })[0]!;
+    const execResult = await tool.execute({
+      owner: 'octocat',
+      repo: 'Hello-World',
+      title: 'Found a bug',
+    });
+
+    expect(tool.name).toBe('Github_CreateIssue');
+    expect(tool.description).toBe(sampleTool.description);
+    // Verify parameters validation works correctly
+    expect(() => {
+      tool.parameters.parse({
+        owner: 'octocat',
+        repo: 'Hello-World',
+        title: 'Found a bug',
+      });
+    }).not.toThrow();
+    expect(execResult).toBe(mockExecuteResponse);
+  });
+
+  it('toZodToolSet maps tools by normalized name', () => {
+    const toolSet = toZodToolSet({ tools: [sampleTool], client, userId });
+
+    expect(toolSet['Github_CreateIssue']).toBeDefined();
+    expect(toolSet['Github_CreateIssue']!.name).toBe('Github_CreateIssue');
+  });
+});


### PR DESCRIPTION
Working on the Vercel AI SDK documentation, I noticed a bit of verbosity when transforming an array of tools into an object:

```ts
export const googleTools = Object.fromEntries(
    toZod({
        client: arcade,
        tools: googleToolkit.items,
        userId: "<YOUR_USER_ID>", // Your app's internal ID for the user (an email, UUID, etc). It's used internally to identify your user in Arcade
    }).map((tool) => [tool.name, {
        ...tool,
        execute: tool.executeOrAuthorize
    }])
)
```

Also, the `execute` function throws an error by default, which needs to be handled on the client side:

```ts
try {
    const result = await generateText({
        model,
        prompt,
        tools,
        maxSteps: 5,
    })

    return result.text
} catch (error) {
    if (error instanceof ToolExecutionError && error.cause instanceof PermissionDeniedError) {
        const response = await getAuthorizationResponse(error.toolName, user_id)
        return `Authorization Required: Please visit this link to connect your Google account: ${url}`
    }
    throw error
}
```

So I did a bit of refactoring and added a few improvements to enhance the DX. One of them is `toZodToolSet`, which returns the tools as an object where the key is the name of the tool:

```ts
const zodTools = toZodToolSet({
	tools: listEmails.items,
	client: arcade,
	userId: "demo@gmail.com",
});

// Returns
{
  Google_ListEmailsByHeader: {
    name: 'Google_ListEmailsByHeader',
    description: 'Search for emails by header using the Gmail API.\n' +
    ...
  },
  Google_ListEmails: {
    name: 'Google_ListEmails',
    description: 'Read emails from a Gmail account and extract plain text content.',
    ...
  }
}
```

I also added an `executeFactory` with two prebuilt execute functions.

- The `executeZodTool ` function just validates the input, and if it’s valid, it runs `client.tools.execute` from our client. 
- The `executeOrAuthorizeZodTool` function, which checks if the tool is authorized. If it’s not, it returns the URL to approve it. If it is, it just executes and returns the result.

This setup also opens the door for future utility `execute` functions that handle more complex flows. For example, we could build a function that manages the entire process: checks if the tool is authorized, waits for completion if needed, then executes the tool — all while reporting status changes via iterators, callbacks, events, or whatever we want to build 😄.

Switching between `execute` and `executeOrAuthorize` looks like this:

```ts
import { executeZodTool, toZodToolSet} from "@arcadeai/arcadejs/lib";
const zodTools = toZodToolSet({
	tools: listEmails.items,
	client: arcade,
	userId: "demo@gmail.com",
	executeFactory: executeZodTool, // This is the default value, so users typically won't add this line
});
or

import { executeOrAuthorizeZodTool, toZodToolSet} from "@arcadeai/arcadejs/lib";
const zodTools = toZodToolSet({
	tools: listEmails.items,
	client: arcade,
	userId: "demo@gmail.com",
	executeFactory: executeOrAuthorizeZodTool,
});
```

I would like your opinion on calling this executeFactory, or if this should be just something like `executeFn` or `execute`

