### PR TITLE
feat: allow optional parameters to be nullable

### DIFF
--- a/src/lib/zod/zod.ts
+++ b/src/lib/zod/zod.ts
@@ -37,7 +37,7 @@ export function convertParametersToZodSchema(parameters: ToolDefinition.Input): 
     let zodType = convertValueSchemaToZod(value_schema);
 
     if (!required) {
-      zodType = zodType.optional();
+      zodType = zodType.nullable().optional();
     }
 
     schemaObj[name] = zodType;


### PR DESCRIPTION
OpenAI agents require that `optional` parameters be `nullable`. This seems like a good pattern, so I will add it to our utility function.