### PR TITLE
Fix parameters type

### DIFF
--- a/src/lib/zod/types.ts
+++ b/src/lib/zod/types.ts
@@ -23,7 +23,7 @@ export interface ZodToolSchema {
   /** Optional, human-readable description */
   description?: string | undefined;
   /** Zod schema for validating tool parameters */
-  parameters: z.ZodType;
+  parameters: z.ZodObject<z.ZodRawShape>;
   /** Zod schema for validating tool output (if any) */
   output: z.ZodType | undefined;
 }

--- a/src/lib/zod/zod.ts
+++ b/src/lib/zod/zod.ts
@@ -25,7 +25,7 @@ export function isAuthorizationRequiredError(error: Error): boolean {
 /**
  * Converts Arcade Tool Input to Zod schema
  */
-export function convertParametersToZodSchema(parameters: ToolDefinition.Input): z.ZodType {
+export function convertParametersToZodSchema(parameters: ToolDefinition.Input): z.ZodObject<z.ZodRawShape> {
   if (!parameters.parameters || !Array.isArray(parameters.parameters)) {
     return z.object({});
   }


### PR DESCRIPTION
We were using `ZodType`, which is the more generic type in Zod, and the parameter will always be an object. This PR updates the `parameters` type to use `ZodObject`.