### PR TITLE
feat(client): userVerification.confirm() for OAuth user verification

### DIFF
--- a/examples/userVerification.ts
+++ b/examples/userVerification.ts
@@ -2,7 +2,7 @@ import { Arcade } from '../src/index';
 
 // Initialize the Arcade client
 // (uses the ARCADE_API_KEY environment variable by default)
-const arcade = new Arcade();
+const client = new Arcade();
 
 async function confirmUser() {
   try {
@@ -13,7 +13,7 @@ async function confirmUser() {
     const user_id = 'user_id';
 
     // Confirm the user
-    const response = await arcade.userVerification.confirm(flow_id, user_id);
+    const response = await client.userVerification.confirm(flow_id, user_id);
 
     console.log('User confirmed successfully!');
     console.log('Auth ID:', response.auth_id);

--- a/examples/userVerification.ts
+++ b/examples/userVerification.ts
@@ -1,0 +1,29 @@
+import { Arcade } from '../src/index';
+
+// Initialize the Arcade client
+// (uses the ARCADE_API_KEY environment variable by default)
+const arcade = new Arcade();
+
+async function confirmUser() {
+  try {
+    // Get the flow ID from the query string
+    const flow_id = 'flow_id';
+
+    // Get the user ID from a session cookie or other secure storage
+    const user_id = 'user_id';
+
+    // Confirm the user
+    const response = await arcade.userVerification.confirm(flow_id, user_id);
+
+    console.log('User confirmed successfully!');
+    console.log('Auth ID:', response.auth_id);
+
+    if (response.next_uri) {
+      console.log('Redirecting to:', response.next_uri);
+      // In a real application, you would redirect the user:
+      // window.location.href = response.next_uri;
+    }
+  } catch (error) {
+    console.error('Failed to confirm user:', error);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   Tools,
   ValueSchema,
 } from './resources/tools/tools';
+import { UserVerification } from './lib/userVerification';
 
 export interface ClientOptions {
   /**
@@ -163,6 +164,7 @@ export class Arcade extends Core.APIClient {
   chat: API.Chat = new API.Chat(this);
   tools: API.Tools = new API.Tools(this);
   workers: API.Workers = new API.Workers(this);
+  userVerification: UserVerification = new UserVerification(this);
 
   /**
    * Check whether the base URL is set to its default.

--- a/src/lib/userVerification/index.ts
+++ b/src/lib/userVerification/index.ts
@@ -1,0 +1,31 @@
+import { APIResource } from '../../resource';
+
+export type ConfirmUserOptions = {
+  host?: string;
+};
+
+export interface ConfirmUserResponse {
+  auth_id: string;
+  next_uri: string;
+}
+
+const defaultCoordinator: string = 'https://cloud.arcade.dev';
+const verifyPath: string = '/api/v1/oauth/confirm_user';
+
+export class UserVerification extends APIResource {
+  confirm(flow_id: string, user_id: string, options?: ConfirmUserOptions): Promise<ConfirmUserResponse> {
+    let host = options?.host || defaultCoordinator;
+    if (host.endsWith('/')) {
+      host = host.substring(0, host.length - 1);
+    }
+    const url = host + verifyPath;
+
+    // Build up the request and send it
+    return this._client.post(url, {
+      body: {
+        flow_id,
+        user_id,
+      },
+    });
+  }
+}

--- a/src/lib/userVerification/index.ts
+++ b/src/lib/userVerification/index.ts
@@ -26,6 +26,9 @@ export class UserVerification extends APIResource {
         flow_id,
         user_id,
       },
+      headers: {
+        Authorization: 'Bearer ' + this._client.apiKey,
+      },
     });
   }
 }

--- a/src/lib/userVerification/index.ts
+++ b/src/lib/userVerification/index.ts
@@ -1,7 +1,7 @@
 import { APIResource } from '../../resource';
 
 export type ConfirmUserOptions = {
-  host?: string;
+  baseURL?: string;
 };
 
 export interface ConfirmUserResponse {
@@ -14,7 +14,7 @@ const verifyPath: string = '/api/v1/oauth/confirm_user';
 
 export class UserVerification extends APIResource {
   confirm(flow_id: string, user_id: string, options?: ConfirmUserOptions): Promise<ConfirmUserResponse> {
-    let host = options?.host || defaultCoordinator;
+    let host = options?.baseURL || defaultCoordinator;
     if (host.endsWith('/')) {
       host = host.substring(0, host.length - 1);
     }

--- a/tests/lib/userVerification.test.ts
+++ b/tests/lib/userVerification.test.ts
@@ -62,7 +62,7 @@ describe('UserVerification', () => {
       (client as any).fetch = mockFetch;
 
       const response = await client.userVerification.confirm('flow_789', 'user_012', {
-        host: 'https://self-hosted.example.com',
+        baseURL: 'https://self-hosted.example.com',
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -90,7 +90,7 @@ describe('UserVerification', () => {
       (client as any).fetch = mockFetch;
 
       await client.userVerification.confirm('flow_abc', 'user_def', {
-        host: 'https://trailing-slash.example.com/',
+        baseURL: 'https://trailing-slash.example.com/',
       });
 
       expect(mockFetch).toHaveBeenCalledWith(

--- a/tests/lib/userVerification.test.ts
+++ b/tests/lib/userVerification.test.ts
@@ -1,0 +1,119 @@
+import { Headers } from 'node-fetch';
+import { Arcade } from '../../src/index';
+
+describe('UserVerification', () => {
+  const client = new Arcade({
+    apiKey: 'test-api-key',
+  });
+
+  describe('confirm', () => {
+    it('should make a POST request to the default coordinator', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          auth_id: 'ac_2zKml...',
+          next_uri: 'https://example.com/callback',
+        }),
+      });
+
+      // Override fetch for testing
+      (client as any).fetch = mockFetch;
+
+      const response = await client.userVerification.confirm('flow_123', 'user_456');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://cloud.arcade.dev/api/v1/oauth/confirm_user',
+        expect.objectContaining({
+          method: 'post',
+          headers: expect.objectContaining({
+            authorization: 'test-api-key',
+            'content-type': 'application/json',
+          }),
+          body: JSON.stringify(
+            {
+              flow_id: 'flow_123',
+              user_id: 'user_456',
+            },
+            null,
+            2,
+          ),
+        }),
+      );
+
+      expect(response).toEqual({
+        auth_id: 'ac_2zKml...',
+        next_uri: 'https://example.com/callback',
+      });
+    });
+
+    it('should use custom host when provided', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          auth_id: 'ac_custom...',
+          next_uri: 'https://custom.example.com/callback',
+        }),
+      });
+
+      (client as any).fetch = mockFetch;
+
+      const response = await client.userVerification.confirm('flow_789', 'user_012', {
+        host: 'https://self-hosted.example.com',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://self-hosted.example.com/api/v1/oauth/confirm_user',
+        expect.any(Object),
+      );
+
+      expect(response).toEqual({
+        auth_id: 'ac_custom...',
+        next_uri: 'https://custom.example.com/callback',
+      });
+    });
+
+    it('should handle trailing slash in custom host', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          auth_id: 'ac_slash...',
+          next_uri: 'https://example.com',
+        }),
+      });
+
+      (client as any).fetch = mockFetch;
+
+      await client.userVerification.confirm('flow_abc', 'user_def', {
+        host: 'https://trailing-slash.example.com/',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://trailing-slash.example.com/api/v1/oauth/confirm_user',
+        expect.any(Object),
+      );
+    });
+
+    it('should handle error responses', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: async () =>
+          JSON.stringify({
+            code: 400,
+            msg: 'An error occurred during verification',
+          }),
+      });
+
+      (client as any).fetch = mockFetch;
+
+      await expect(client.userVerification.confirm('invalid_flow', 'invalid_user')).rejects.toThrow();
+    });
+  });
+});

--- a/tests/lib/userVerification.test.ts
+++ b/tests/lib/userVerification.test.ts
@@ -26,7 +26,7 @@ describe('UserVerification', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'https://cloud.arcade.dev/api/v1/oauth/confirm_user',
         expect.objectContaining({
-          method: 'post',
+          method: 'POST',
           headers: expect.objectContaining({
             authorization: 'test-api-key',
             'content-type': 'application/json',

--- a/tests/lib/userVerification.test.ts
+++ b/tests/lib/userVerification.test.ts
@@ -28,7 +28,7 @@ describe('UserVerification', () => {
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
-            authorization: 'test-api-key',
+            authorization: 'Bearer test-api-key',
             'content-type': 'application/json',
           }),
           body: JSON.stringify(


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86b5q9mn1

Adds client-side support for the `confirm_user` API. Since this is not part of the direct Engine API, it is not part of the typical OpenAPI generation process.